### PR TITLE
v0.2.0: SQLite query layer and reports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,13 +23,15 @@ uv run ruff format src/ tests/ # format
 src/ox/
   parse.py   - Tree-sitter node → data structures (the core parser)
   data.py    - Dataclasses: TrainingSet, Movement, TrainingSession, TrainingLog
+  db.py      - In-memory SQLite layer: create_db(log) → Connection
   units.py   - Pint unit registry (shared instance)
   cli.py     - Click CLI with interactive REPL (ox command)
   lsp.py     - LSP server for .ox files (ox-lsp command)
 tests/
-  conftest.py        - Shared fixtures (simple_log_content, weight_edge_cases)
+  conftest.py        - Shared fixtures (simple_log_content, weight_edge_cases, simple_db)
   test_parse.py      - Unit tests for weight/rep parsing
   test_data.py       - Unit tests for data structures
+  test_db.py         - Tests for SQLite schema, loading, views, queries
   test_integration.py - End-to-end parsing tests
 tree-sitter-ox/
   grammar.js  - Tree-sitter grammar definition for .ox format

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# Ox
+
+Plain text training log parser and analyzer.
+Uses a custom tree-sitter grammar to parse `.ox` log files into structured data for querying and analysis.
+
+
+## Usage Notes
+- if you edit `tree-sitter/grammar.js` run `tree-sitter generate` then reinstall the package before doing any additional work.
+
+## Commands
+
+```bash
+uv run pytest                  # run all tests
+uv run pytest tests/test_parse.py  # run a specific test file
+uv run ruff check src/ tests/  # lint
+uv run ruff format src/ tests/ # format
+```
+
+## Project Structure
+
+```
+src/ox/
+  parse.py   - Tree-sitter node → data structures (the core parser)
+  data.py    - Dataclasses: TrainingSet, Movement, TrainingSession, TrainingLog
+  units.py   - Pint unit registry (shared instance)
+  cli.py     - Click CLI with interactive REPL (ox command)
+  lsp.py     - LSP server for .ox files (ox-lsp command)
+tests/
+  conftest.py        - Shared fixtures (simple_log_content, weight_edge_cases)
+  test_parse.py      - Unit tests for weight/rep parsing
+  test_data.py       - Unit tests for data structures
+  test_integration.py - End-to-end parsing tests
+tree-sitter-ox/
+  grammar.js  - Tree-sitter grammar definition for .ox format
+example/
+  example.ox  - Reference training log with all supported formats
+```
+
+## .ox File Format
+
+```
+# Comments start with #
+
+# Single-line entry: date flag exercise: weight reps "note"
+2025-01-10 * pullups: BW 5x10
+
+# Session block: multiple exercises in one session
+@session
+2025-01-11 * Upper Day
+bench-press: 135lbs 5x5
+kb-oh-press: 24kg 5/5/5
+@end
+
+# Flags: * = completed, ! = planned, W = weigh-in
+# Weight formats: 24kg, 135lbs, BW (bodyweight), 24kg+32kg (combined), 24kg/32kg/48kg (progressive)
+# Rep formats: 5x5 (sets x reps), 5/5/5 (per-set reps)
+```
+
+## Conventions
+
+- Python 3.12, dependencies managed with uv
+- Frozen dataclasses with `slots=True` for data structures
+- `pint.Quantity` for all weight values (never raw numbers)
+- Exercise names are hyphenated lowercase (e.g. `kb-oh-press`, `bench-press`)
+- `to_ox()` methods serialize back to .ox format (round-trip support)
+- Tree-sitter nodes are processed in `parse.py`; data structures live in `data.py` — keep this separation
+
+## Known Issues
+- Progressive weights for the same movement require explicit units, this is known bug and applicable tests are skipped.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@ Uses a custom tree-sitter grammar to parse `.ox` log files into structured data 
 
 
 ## Usage Notes
+- `SPEC.md` is your guide for the goals, non-goals, and roadmap for this repo.
 - if you edit `tree-sitter/grammar.js` run `tree-sitter generate` then reinstall the package before doing any additional work.
 
 ## Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ src/ox/
   parse.py   - Tree-sitter node → data structures (the core parser)
   data.py    - Dataclasses: TrainingSet, Movement, TrainingSession, TrainingLog
   db.py      - In-memory SQLite layer: create_db(log) → Connection
+  reports.py - Standard reports: volume_over_time, session_matrix, REPORTS registry
   units.py   - Pint unit registry (shared instance)
   cli.py     - Click CLI with interactive REPL (ox command)
   lsp.py     - LSP server for .ox files (ox-lsp command)
@@ -32,6 +33,7 @@ tests/
   test_parse.py      - Unit tests for weight/rep parsing
   test_data.py       - Unit tests for data structures
   test_db.py         - Tests for SQLite schema, loading, views, queries
+  test_reports.py    - Tests for reports, arg parsing, registry
   test_integration.py - End-to-end parsing tests
 tree-sitter-ox/
   grammar.js  - Tree-sitter grammar definition for .ox format

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,96 @@
+# Ox — Product Spec
+
+## What is ox?
+
+A plain text training log format and toolchain.
+Write workouts in a `.ox` text file, parse them into structured data, analyze progress over time.
+Inspired by [Beancount](https://github.com/beancount/beancount) — plain text accounting, but for training.
+A big guiding principle is that one should plan their training over the course of years and decades, not weeks and months.
+So, you should be able to track progress over that time frame.
+
+## Who is it for?
+
+People who train consistently over years and want to own their data.
+Developers and power users comfortable with text files and CLIs.
+
+## Core Principles
+
+- **Plain text is the source of truth.** The `.ox` file is the canonical record. Everything else is derived from it.
+- **No cloud, no accounts, no lock-in.** Your data is a text file on your filesystem.
+- **Paper-like flexibility with software analytics.** The format should be as easy to write as scribbling in a notebook, but parseable for real analysis.
+- **Long-lived data.** A log written today should be readable in 20 years. Text outlasts apps.
+
+## Current State
+
+### What works today
+
+- **Tree-sitter grammar** (`tree-sitter-ox/grammar.js`) parses `.ox` files into syntax trees
+- **Python parser** (`src/ox/parse.py`) converts tree-sitter nodes into dataclasses
+- **Data model** (`src/ox/data.py`) — `TrainingSet`, `Movement`, `TrainingSession`, `TrainingLog`
+- **CLI** (`src/ox/cli.py`) — interactive REPL with `stats` and `history` commands
+- **LSP** (`src/ox/lsp.py`) — basic diagnostics (syntax errors) for editor integration
+- **VSCode extension** — syntax highlighting
+- **Round-trip serialization** — `to_ox()` methods write data back to `.ox` format
+- **Unit handling** — weights tracked as `pint.Quantity` (kg, lbs)
+
+### What's incomplete
+
+- Weigh-in processing (`W` flag) — parsed by tree-sitter but not processed into data structures
+- Planned sessions (`!` flag) — parsed but mostly ignored in analysis
+- Exercise definitions (`@exercise` blocks) — parsed by tree-sitter but not used in analysis
+- Template blocks (`@template`) — grammar exists, no processing
+- Progressive implied weights (e.g. `160/185/210lbs`) — known parsing bug
+- LSP only does diagnostics — no completions, hover, or go-to-definition
+- Tree-sitter grammar only accepts `kg` and `lbs` — should accept any valid pint mass unit
+- `pint.Quantity` should be used for time as well
+- for the CLI:
+  - after loading, options the user has should be listed, with a comprehensive help menu available upon request
+  - options will include: list excercises (sorted by most frequently found in the log), stats and history as is, volume progression
+
+## Direction
+
+### SQLite query layer
+
+The current analysis is hardcoded in Python methods on `TrainingLog` (`stats`, `movement_history`, etc.). This limits what users can ask of their data.
+
+**Plan:** After parsing `.ox` into dataclasses, load into an in-memory SQLite database. This gives:
+
+- Users can write arbitrary SQL queries against their training data
+- A `query` CLI command (e.g. `ox query "SELECT ..."`)
+- A foundation for plugins — any analysis is just a SQL query
+- No new dependencies (sqlite3 is in the stdlib)
+
+The `.ox` file remains the source of truth. SQLite is a derived, ephemeral view — re-created from the parsed file each session. No caching, no sync issues.
+
+**Schema direction:**
+
+```
+sessions(id, date, flag, name)
+movements(id, session_id, name, note)
+sets(id, movement_id, reps, weight_magnitude, weight_unit)
+```
+
+### Richer analysis
+
+- Cycle tracking — micro/meso/macro periodization
+- Exercise definitions feeding into analysis (e.g. grouping by movement pattern)
+- Track total volume of a given excercise over time (for example, total volume of kb-swings on a weekly basis this year)
+
+Create a plugin framework that allows users to write their own, some included ones might be:
+
+- Estimated 1RM calculations from weight/rep data (useful for percentage-based programs like 5/3/1)
+- Generate specific plans from a known progression (like the 4-week cycle in the Wendler 5/3/1 given a training max)
+
+### Better editor experience
+
+- LSP completions (exercise names, session templates)
+- Hover info (exercise definitions, recent history for a movement)
+- Snippets for common entry patterns
+- Broader unit support in the grammar (any valid pint mass unit)
+
+## Non-Goals
+
+- **Not a workout planner or coach.** Ox records and analyzes what you did. It doesn't tell you what to do.
+- **Not a web app or mobile app.** It's a CLI tool and text format. Edit your `.ox` file however you want.
+- **Not a social platform.** No sharing, leaderboards, or community features.
+- **No proprietary format extensions.** The `.ox` format should stay simple enough to read with no tooling at all.

--- a/SPEC.md
+++ b/SPEC.md
@@ -81,6 +81,10 @@ Create a plugin framework that allows users to write their own, some included on
 - Estimated 1RM calculations from weight/rep data (useful for percentage-based programs like 5/3/1)
 - Generate specific plans from a known progression (like the 4-week cycle in the Wendler 5/3/1 given a training max)
 
+### CLI
+- more comprehensive help menu
+- auto-population is related to ox log excercises (when I type the history command, the autocomplete will help suggest relevant excercises)
+
 ### Better editor experience
 
 - LSP completions (exercise names, session templates)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ox"
-version = "0.1.0"
+version = "0.2.0"
 description = "Plain text training log parser and analyzer"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/ox/cli.py
+++ b/src/ox/cli.py
@@ -212,7 +212,7 @@ def run_report(conn: sqlite3.Connection, report_name: str, arg_string: str):
 
 @click.command()
 @click.argument('file', type=click.Path(exists=True, path_type=Path))
-@click.version_option(version="0.1.0")
+@click.version_option(version="0.2.0")
 def cli(file):
     """Interactive training log analyzer.
 

--- a/src/ox/cli.py
+++ b/src/ox/cli.py
@@ -1,5 +1,7 @@
 """Command-line interface for ox."""
 
+import sqlite3
+
 import click
 from pathlib import Path
 from tree_sitter import Language, Parser
@@ -12,6 +14,7 @@ from prompt_toolkit.completion import WordCompleter
 
 from ox.parse import process_node
 from ox.data import TrainingLog
+from ox.db import create_db
 
 console = Console()
 
@@ -50,6 +53,8 @@ def show_help():
     console.print("\n[bold cyan]Available Commands:[/bold cyan]")
     console.print("  [green]stats[/green]              - Show summary statistics for all exercises")
     console.print("  [green]history[/green] EXERCISE   - Show training history for an exercise")
+    console.print("  [green]query[/green] SQL          - Run a SQL query against your training data")
+    console.print("  [green]tables[/green]             - Show available tables and views")
     console.print("  [green]help[/green]               - Show this help message")
     console.print("  [green]exit[/green] or [green]quit[/green]     - Exit the program")
     console.print()
@@ -120,6 +125,40 @@ def show_history(log: TrainingLog, exercise: str):
     console.print()  # Blank line after table
 
 
+def show_query(conn: sqlite3.Connection, sql: str):
+    """Execute a SQL query and display results as a rich table."""
+    try:
+        cursor = conn.execute(sql)
+        rows = cursor.fetchall()
+        if not rows:
+            console.print("[yellow]No results.[/yellow]\n")
+            return
+
+        columns = [desc[0] for desc in cursor.description]
+
+        table = Table(box=DEFAULT_TABLE_BOX)
+        for col in columns:
+            table.add_column(col, style="cyan")
+
+        for row in rows:
+            table.add_row(*(str(v) for v in row))
+
+        console.print(table)
+        console.print(f"\n[dim]{len(rows)} row(s)[/dim]\n")
+    except Exception as e:
+        console.print(f"[red]SQL error: {e}[/red]\n")
+
+
+def show_tables(conn: sqlite3.Connection):
+    """Show available tables and views."""
+    rows = conn.execute(
+        "SELECT type, name FROM sqlite_master WHERE type IN ('table', 'view') ORDER BY type, name"
+    ).fetchall()
+    for type_, name in rows:
+        console.print(f"  [green]{name}[/green] ({type_})")
+    console.print()
+
+
 @click.command()
 @click.argument('file', type=click.Path(exists=True, path_type=Path))
 @click.version_option(version="0.1.0")
@@ -132,6 +171,7 @@ def cli(file):
     try:
         console.print(f"[cyan]Loading {file}...[/cyan]")
         log = parse_file(file)
+        db = create_db(log)
         console.print(
             f"[green]✓[/green] Loaded {len(log.completed_sessions)} completed, "
             f"{len(log.planned_sessions)} planned sessions\n"
@@ -141,7 +181,7 @@ def cli(file):
         raise click.Abort()
 
     # Setup tab completion for commands
-    commands = ['history', 'stats', 'help', 'exit', 'quit']
+    commands = ['history', 'stats', 'query', 'tables', 'help', 'exit', 'quit']
     completer = WordCompleter(commands, ignore_case=True)
 
     # Create prompt session
@@ -179,6 +219,15 @@ def cli(file):
                 else:
                     show_history(log, args)
 
+            elif command == "query":
+                if not args:
+                    console.print("[yellow]Usage: query SELECT ...[/yellow]")
+                else:
+                    show_query(db, args)
+
+            elif command == "tables":
+                show_tables(db)
+
             else:
                 console.print(f"[red]Unknown command: {command}[/red]")
                 console.print("Type 'help' for available commands")
@@ -187,6 +236,8 @@ def cli(file):
             continue  # Ctrl+C just cancels current line
         except EOFError:
             break  # Ctrl+D exits
+
+    db.close()
 
 
 if __name__ == '__main__':

--- a/src/ox/db.py
+++ b/src/ox/db.py
@@ -1,0 +1,99 @@
+"""In-memory SQLite database for training log queries."""
+
+import sqlite3
+from typing import Optional
+
+from pint import Quantity
+
+from ox.data import TrainingLog
+
+SCHEMA = """
+CREATE TABLE sessions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    date TEXT NOT NULL,
+    flag TEXT NOT NULL,
+    name TEXT
+);
+
+CREATE TABLE movements (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    note TEXT,
+    FOREIGN KEY (session_id) REFERENCES sessions(id)
+);
+
+CREATE TABLE sets (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    movement_id INTEGER NOT NULL,
+    reps INTEGER NOT NULL,
+    weight_magnitude REAL,
+    weight_unit TEXT,
+    FOREIGN KEY (movement_id) REFERENCES movements(id)
+);
+
+CREATE VIEW training AS
+SELECT
+    s.id AS session_id,
+    s.date,
+    s.flag,
+    s.name AS session_name,
+    m.id AS movement_id,
+    m.name AS movement_name,
+    m.note AS movement_note,
+    t.id AS set_id,
+    t.reps,
+    t.weight_magnitude,
+    t.weight_unit
+FROM sessions s
+JOIN movements m ON m.session_id = s.id
+JOIN sets t ON t.movement_id = m.id;
+"""
+
+
+def _decompose_weight(weight: Optional[Quantity]) -> tuple[Optional[float], Optional[str]]:
+    """Split a pint Quantity into (magnitude, unit_string) for SQLite storage.
+
+    Returns (None, None) for bodyweight (weight is None).
+    """
+    if weight is None:
+        return None, None
+    return float(weight.magnitude), str(weight.units)
+
+
+def create_db(log: TrainingLog) -> sqlite3.Connection:
+    """Load a TrainingLog into an in-memory SQLite database.
+
+    Args:
+        log: Parsed training log
+
+    Returns:
+        sqlite3.Connection to the in-memory database
+    """
+    conn = sqlite3.connect(":memory:")
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.executescript(SCHEMA)
+
+    for session in log.sessions:
+        cursor = conn.execute(
+            "INSERT INTO sessions (date, flag, name) VALUES (?, ?, ?)",
+            (session.date.isoformat(), session.flag, session.name),
+        )
+        session_id = cursor.lastrowid
+
+        for movement in session.movements:
+            cursor = conn.execute(
+                "INSERT INTO movements (session_id, name, note) VALUES (?, ?, ?)",
+                (session_id, movement.name, movement.note),
+            )
+            movement_id = cursor.lastrowid
+
+            for training_set in movement.sets:
+                mag, unit = _decompose_weight(training_set.weight)
+                conn.execute(
+                    "INSERT INTO sets (movement_id, reps, weight_magnitude, weight_unit) VALUES (?, ?, ?, ?)",
+                    (movement_id, training_set.reps, mag, unit),
+                )
+
+    conn.commit()
+    return conn

--- a/src/ox/reports.py
+++ b/src/ox/reports.py
@@ -1,0 +1,210 @@
+"""Standard reports for training log analysis.
+
+Each report function takes a sqlite3.Connection and keyword arguments,
+and returns (columns, rows) — a list of column names and a list of tuples.
+This keeps reports independent of any rendering layer.
+"""
+
+import shlex
+import sqlite3
+from collections import defaultdict
+
+TIME_BINS = {
+    "daily": "%Y-%m-%d",
+    "weekly": "%Y-W%W",
+    "monthly": "%Y-%m",
+}
+
+
+def _time_bin_format(bin: str) -> str:
+    """Return strftime format string for a time bin name.
+
+    Args:
+        bin: One of "daily", "weekly", "monthly"
+
+    Raises:
+        ValueError: If bin is not a recognized time bin
+    """
+    if bin not in TIME_BINS:
+        raise ValueError(
+            f"Unknown time bin '{bin}'. Choose from: {', '.join(TIME_BINS)}"
+        )
+    return TIME_BINS[bin]
+
+
+def volume_over_time(
+    conn: sqlite3.Connection, movement: str, bin: str = "weekly"
+) -> tuple[list[str], list[tuple]]:
+    """Volume over time for a single movement.
+
+    Args:
+        conn: SQLite connection with training data
+        movement: Movement name to filter by
+        bin: Time bin size ("daily", "weekly", "monthly")
+
+    Returns:
+        (columns, rows) where columns are
+        ["period", "total_volume", "total_reps", "avg_weight_per_rep"]
+    """
+    fmt = _time_bin_format(bin)
+    rows = conn.execute(
+        f"""
+        SELECT
+            strftime('{fmt}', date) AS period,
+            ROUND(SUM(reps * weight_magnitude), 1) AS total_volume,
+            SUM(reps) AS total_reps,
+            ROUND(SUM(reps * weight_magnitude) * 1.0 / SUM(reps), 1) AS avg_weight_per_rep
+        FROM training
+        WHERE movement_name = ?
+        GROUP BY period
+        ORDER BY period
+        """,
+        (movement,),
+    ).fetchall()
+    columns = ["period", "total_volume", "total_reps", "avg_weight_per_rep"]
+    return columns, rows
+
+
+def session_matrix(
+    conn: sqlite3.Connection, bin: str = "weekly"
+) -> tuple[list[str], list[tuple]]:
+    """Session count per movement per time period.
+
+    Rows are time periods, columns are movement names (sorted by frequency,
+    most common first).
+
+    Args:
+        conn: SQLite connection with training data
+        bin: Time bin size ("daily", "weekly", "monthly")
+
+    Returns:
+        (columns, rows) where columns are ["period", movement1, movement2, ...]
+    """
+    fmt = _time_bin_format(bin)
+
+    # Get movement names sorted by total frequency (most common first)
+    movement_names = [
+        r[0]
+        for r in conn.execute(
+            """
+            SELECT name, COUNT(DISTINCT session_id) AS freq
+            FROM movements
+            GROUP BY name
+            ORDER BY freq DESC, name
+            """
+        ).fetchall()
+    ]
+
+    # Get per-period, per-movement session counts
+    raw = conn.execute(
+        f"""
+        SELECT
+            strftime('{fmt}', s.date) AS period,
+            m.name AS movement_name,
+            COUNT(DISTINCT s.id) AS session_count
+        FROM sessions s
+        JOIN movements m ON m.session_id = s.id
+        GROUP BY period, movement_name
+        ORDER BY period
+        """
+    ).fetchall()
+
+    # Pivot into {period: {movement: count}}
+    pivot = defaultdict(lambda: defaultdict(int))
+    periods = []
+    for period, movement_name, count in raw:
+        if period not in pivot:
+            periods.append(period)
+        pivot[period][movement_name] = count
+
+    # Flatten to rows
+    columns = ["period"] + movement_names
+    rows = []
+    for period in periods:
+        row = [period] + [pivot[period].get(m, 0) for m in movement_names]
+        rows.append(tuple(row))
+
+    return columns, rows
+
+
+def parse_report_args(params: list[dict], arg_string: str) -> dict:
+    """Parse --flag value pairs from a string against a param spec.
+
+    Args:
+        params: List of param dicts with keys: name, type, required, default (optional)
+        arg_string: Raw argument string (e.g. "--movement kb-swing --bin weekly")
+
+    Returns:
+        Dict of parsed keyword arguments
+
+    Raises:
+        ValueError: If required params are missing or unknown flags are given
+    """
+    tokens = shlex.split(arg_string) if arg_string.strip() else []
+    parsed = {}
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        if token.startswith("--"):
+            key = token[2:]
+            param = next((p for p in params if p["name"] == key), None)
+            if param is None:
+                raise ValueError(f"Unknown flag: --{key}")
+            if i + 1 >= len(tokens):
+                raise ValueError(f"--{key} requires a value")
+            parsed[key] = param["type"](tokens[i + 1])
+            i += 2
+        else:
+            raise ValueError(f"Unexpected argument: {token}")
+
+    # Apply defaults and check required
+    for param in params:
+        name = param["name"]
+        if name not in parsed:
+            if param.get("required", False):
+                required_names = [
+                    f"--{p['name']}" for p in params if p.get("required", False)
+                ]
+                raise ValueError(f"Missing required flag(s): {', '.join(required_names)}")
+            parsed[name] = param.get("default")
+
+    return parsed
+
+
+def report_usage(name: str, entry: dict) -> str:
+    """Generate a usage string for a report.
+
+    Args:
+        name: Report name
+        entry: Report registry entry
+
+    Returns:
+        Formatted usage string
+    """
+    parts = [f"report {name}"]
+    for p in entry["params"]:
+        flag = f"--{p['name']} <{p['name']}>"
+        if p.get("required", False):
+            parts.append(flag)
+        else:
+            parts.append(f"[{flag}]")
+    return " ".join(parts)
+
+
+REPORTS = {
+    "volume": {
+        "fn": volume_over_time,
+        "description": "Volume over time for a movement",
+        "params": [
+            {"name": "movement", "type": str, "required": True},
+            {"name": "bin", "type": str, "default": "weekly", "required": False},
+        ],
+    },
+    "matrix": {
+        "fn": session_matrix,
+        "description": "Session count per movement per time period",
+        "params": [
+            {"name": "bin", "type": str, "default": "weekly", "required": False},
+        ],
+    },
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,11 @@
 """Shared test fixtures and configuration."""
 
+from pathlib import Path
+
 import pytest
+
+from ox.cli import parse_file
+from ox.db import create_db
 
 
 @pytest.fixture
@@ -57,3 +62,21 @@ def weight_edge_cases():
         "progressive_explicit": "24kg/32kg/48kg",
         "progressive_implied": "160/185/210lbs",  # This is the known bug
     }
+
+
+@pytest.fixture
+def simple_db(simple_log_file):
+    """In-memory SQLite database loaded from the simple test log."""
+    log = parse_file(simple_log_file)
+    conn = create_db(log)
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def example_db():
+    """In-memory SQLite database loaded from the example training log."""
+    log = parse_file(Path(__file__).parent.parent / "example" / "example.ox")
+    conn = create_db(log)
+    yield conn
+    conn.close()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,256 @@
+"""Tests for the in-memory SQLite database layer."""
+
+import sqlite3
+
+import pytest
+
+from ox.data import TrainingLog
+from ox.db import create_db, _decompose_weight
+from ox.units import ureg
+
+
+class TestSchema:
+    """Verify the database schema is created correctly."""
+
+    def test_sessions_table_exists(self, simple_db):
+        rows = simple_db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='sessions'"
+        ).fetchall()
+        assert len(rows) == 1
+
+    def test_movements_table_exists(self, simple_db):
+        rows = simple_db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='movements'"
+        ).fetchall()
+        assert len(rows) == 1
+
+    def test_sets_table_exists(self, simple_db):
+        rows = simple_db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='sets'"
+        ).fetchall()
+        assert len(rows) == 1
+
+    def test_training_view_exists(self, simple_db):
+        rows = simple_db.execute(
+            "SELECT name FROM sqlite_master WHERE type='view' AND name='training'"
+        ).fetchall()
+        assert len(rows) == 1
+
+    def test_foreign_keys_enforced(self, simple_db):
+        with pytest.raises(sqlite3.IntegrityError):
+            simple_db.execute(
+                "INSERT INTO movements (session_id, name) VALUES (9999, 'fake')"
+            )
+
+
+class TestDecomposeWeight:
+    """Verify _decompose_weight splits Quantity objects correctly."""
+
+    def test_kg(self):
+        mag, unit = _decompose_weight(24.0 * ureg.kilogram)
+        assert mag == 24.0
+        assert unit == "kilogram"
+
+    def test_lbs(self):
+        mag, unit = _decompose_weight(135.0 * ureg.pounds)
+        assert mag == 135.0
+        assert unit == "pound"
+
+    def test_bodyweight_none(self):
+        mag, unit = _decompose_weight(None)
+        assert mag is None
+        assert unit is None
+
+
+class TestDataLoading:
+    """Verify data is loaded correctly from TrainingLog.
+
+    The simple_log_content fixture has:
+    - 1 single-line entry: 2025-01-10 * pullups: BW 5x10 (5 sets, no weight)
+    - 1 completed session: 2025-01-11 * Upper Day
+        - bench-press: 135lbs 5x5 (5 sets)
+        - kb-oh-press: 24kg 5/5/5 (3 sets)
+    - 1 planned session: 2025-01-12 ! Lower Day
+        - squat: 185lbs 3x5 (3 sets)
+    """
+
+    def test_session_count(self, simple_db):
+        count = simple_db.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+        assert count == 3
+
+    def test_movement_count(self, simple_db):
+        count = simple_db.execute("SELECT COUNT(*) FROM movements").fetchone()[0]
+        assert count == 4
+
+    def test_set_count(self, simple_db):
+        count = simple_db.execute("SELECT COUNT(*) FROM sets").fetchone()[0]
+        assert count == 16
+
+    def test_session_dates(self, simple_db):
+        dates = [
+            r[0] for r in simple_db.execute("SELECT date FROM sessions ORDER BY date").fetchall()
+        ]
+        assert dates == ["2025-01-10", "2025-01-11", "2025-01-12"]
+
+    def test_session_flags(self, simple_db):
+        flags = [
+            r[0]
+            for r in simple_db.execute("SELECT flag FROM sessions ORDER BY date").fetchall()
+        ]
+        assert flags == ["*", "*", "!"]
+
+    def test_movement_names(self, simple_db):
+        names = sorted(
+            r[0] for r in simple_db.execute("SELECT name FROM movements").fetchall()
+        )
+        assert names == ["bench-press", "kb-oh-press", "pullups", "squat"]
+
+    def test_session_name_nullable(self, simple_db):
+        """Single-line entries have no session name."""
+        row = simple_db.execute(
+            "SELECT name FROM sessions WHERE date = '2025-01-10'"
+        ).fetchone()
+        assert row[0] is None
+
+    def test_session_name_present(self, simple_db):
+        row = simple_db.execute(
+            "SELECT name FROM sessions WHERE date = '2025-01-11'"
+        ).fetchone()
+        assert row[0] == "Upper Day"
+
+
+class TestWeightInDatabase:
+    """Verify weight magnitude and unit are stored correctly."""
+
+    def test_weighted_set_has_magnitude(self, simple_db):
+        row = simple_db.execute(
+            """SELECT weight_magnitude, weight_unit FROM training
+               WHERE movement_name = 'bench-press' LIMIT 1"""
+        ).fetchone()
+        assert row[0] == 135.0
+        assert row[1] == "pound"
+
+    def test_kg_weight(self, simple_db):
+        row = simple_db.execute(
+            """SELECT weight_magnitude, weight_unit FROM training
+               WHERE movement_name = 'kb-oh-press' LIMIT 1"""
+        ).fetchone()
+        assert row[0] == 24.0
+        assert row[1] == "kilogram"
+
+    def test_bodyweight_is_null(self, simple_db):
+        row = simple_db.execute(
+            """SELECT weight_magnitude, weight_unit FROM training
+               WHERE movement_name = 'pullups' LIMIT 1"""
+        ).fetchone()
+        assert row[0] is None
+        assert row[1] is None
+
+
+class TestTrainingView:
+    """Test the convenience 'training' view."""
+
+    def test_view_returns_all_sets(self, simple_db):
+        count = simple_db.execute("SELECT COUNT(*) FROM training").fetchone()[0]
+        assert count == 16
+
+    def test_view_has_expected_columns(self, simple_db):
+        cursor = simple_db.execute("SELECT * FROM training LIMIT 1")
+        columns = [desc[0] for desc in cursor.description]
+        assert columns == [
+            "session_id",
+            "date",
+            "flag",
+            "session_name",
+            "movement_id",
+            "movement_name",
+            "movement_note",
+            "set_id",
+            "reps",
+            "weight_magnitude",
+            "weight_unit",
+        ]
+
+    def test_filter_by_movement_name(self, simple_db):
+        rows = simple_db.execute(
+            "SELECT * FROM training WHERE movement_name = 'bench-press'"
+        ).fetchall()
+        assert len(rows) == 5
+
+    def test_filter_by_date(self, simple_db):
+        rows = simple_db.execute(
+            "SELECT * FROM training WHERE date = '2025-01-11'"
+        ).fetchall()
+        # Upper Day: bench-press 5 sets + kb-oh-press 3 sets = 8
+        assert len(rows) == 8
+
+
+class TestEdgeCases:
+    """Test edge cases in data loading."""
+
+    def test_empty_log(self):
+        log = TrainingLog(sessions=())
+        conn = create_db(log)
+        count = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+        assert count == 0
+        conn.close()
+
+    def test_movement_with_note(self, example_db):
+        """Notes from the .ox file are stored in the movements table."""
+        rows = example_db.execute(
+            "SELECT note FROM movements WHERE note IS NOT NULL LIMIT 1"
+        ).fetchall()
+        assert len(rows) >= 1
+        assert isinstance(rows[0][0], str)
+
+
+class TestUserQueries:
+    """Test realistic SQL queries a user would write."""
+
+    def test_count_sessions_per_exercise(self, simple_db):
+        rows = simple_db.execute(
+            """SELECT movement_name, COUNT(DISTINCT session_id) as sessions
+               FROM training
+               GROUP BY movement_name
+               ORDER BY sessions DESC"""
+        ).fetchall()
+        # Each movement appears in exactly one session
+        assert all(r[1] == 1 for r in rows)
+        assert len(rows) == 4
+
+    def test_max_weight_per_exercise(self, simple_db):
+        rows = simple_db.execute(
+            """SELECT movement_name, MAX(weight_magnitude) as max_weight, weight_unit
+               FROM training
+               WHERE weight_magnitude IS NOT NULL
+               GROUP BY movement_name"""
+        ).fetchall()
+        results = {r[0]: (r[1], r[2]) for r in rows}
+        assert results["bench-press"] == (135.0, "pound")
+        assert results["kb-oh-press"] == (24.0, "kilogram")
+        assert results["squat"] == (185.0, "pound")
+
+    def test_total_reps_per_exercise(self, simple_db):
+        rows = simple_db.execute(
+            """SELECT movement_name, SUM(reps) as total_reps
+               FROM training
+               GROUP BY movement_name
+               ORDER BY total_reps DESC"""
+        ).fetchall()
+        results = {r[0]: r[1] for r in rows}
+        assert results["pullups"] == 50  # 5x10
+        assert results["bench-press"] == 25  # 5x5
+        assert results["kb-oh-press"] == 15  # 5/5/5
+        assert results["squat"] == 15  # 3x5
+
+    def test_volume_query(self, simple_db):
+        """Total volume = SUM(reps * weight_magnitude) per exercise."""
+        rows = simple_db.execute(
+            """SELECT movement_name, SUM(reps * weight_magnitude) as volume
+               FROM training
+               WHERE weight_magnitude IS NOT NULL
+               GROUP BY movement_name"""
+        ).fetchall()
+        results = {r[0]: r[1] for r in rows}
+        assert results["bench-press"] == 135.0 * 25  # 135 * 5reps * 5sets
+        assert results["kb-oh-press"] == 24.0 * 15  # 24 * (5+5+5)

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,233 @@
+"""Tests for the reports module."""
+
+import pytest
+
+from ox.data import TrainingLog
+from ox.db import create_db
+from ox.reports import (
+    REPORTS,
+    _time_bin_format,
+    parse_report_args,
+    report_usage,
+    session_matrix,
+    volume_over_time,
+)
+
+
+class TestTimeBins:
+    """Test time bin format helper."""
+
+    def test_daily(self):
+        assert _time_bin_format("daily") == "%Y-%m-%d"
+
+    def test_weekly(self):
+        assert _time_bin_format("weekly") == "%Y-W%W"
+
+    def test_monthly(self):
+        assert _time_bin_format("monthly") == "%Y-%m"
+
+    def test_invalid_raises(self):
+        with pytest.raises(ValueError, match="Unknown time bin"):
+            _time_bin_format("yearly")
+
+
+class TestVolumeOverTime:
+    """Test the volume report."""
+
+    def test_columns(self, example_db):
+        columns, _ = volume_over_time(example_db, "squat")
+        assert columns == ["period", "total_volume", "total_reps", "avg_weight_per_rep"]
+
+    def test_weekly_grouping(self, example_db):
+        _, rows = volume_over_time(example_db, "squat", bin="weekly")
+        # squat appears in many weeks in example.ox
+        assert len(rows) > 1
+        # Each row's period should be in YYYY-WXX format
+        for row in rows:
+            assert row[0].startswith("2024-W")
+
+    def test_monthly_grouping(self, example_db):
+        _, rows = volume_over_time(example_db, "squat", bin="monthly")
+        assert len(rows) > 1
+        for row in rows:
+            assert row[0].startswith("2024-")
+            assert len(row[0]) == 7  # "2024-01"
+
+    def test_daily_grouping(self, example_db):
+        _, rows = volume_over_time(example_db, "squat", bin="daily")
+        for row in rows:
+            assert len(row[0]) == 10  # "2024-01-15"
+
+    def test_single_movement_filter(self, example_db):
+        _, rows = volume_over_time(example_db, "squat")
+        # All rows should have non-None volume (squat always has weight)
+        for row in rows:
+            assert row[1] is not None  # total_volume
+            assert row[2] > 0  # total_reps
+
+    def test_bodyweight_movement(self, example_db):
+        """Bodyweight movements have NULL volume since weight_magnitude is NULL."""
+        _, rows = volume_over_time(example_db, "pullup")
+        # Some pullup sets are bodyweight (NULL magnitude), so volume may be None
+        assert len(rows) > 0
+
+    def test_nonexistent_movement(self, example_db):
+        _, rows = volume_over_time(example_db, "nonexistent-exercise")
+        assert rows == []
+
+    def test_volume_values(self, simple_db):
+        """Verify volume calculation against known data.
+
+        simple_log has bench-press: 135lbs 5x5 on 2025-01-11.
+        Total volume = 135 * 25 = 3375.
+        """
+        _, rows = volume_over_time(simple_db, "bench-press", bin="daily")
+        assert len(rows) == 1
+        assert rows[0][0] == "2025-01-11"
+        assert rows[0][1] == 3375.0  # total_volume
+        assert rows[0][2] == 25  # total_reps
+        assert rows[0][3] == 135.0  # avg_weight_per_rep
+
+
+class TestSessionMatrix:
+    """Test the session matrix report."""
+
+    def test_first_column_is_period(self, example_db):
+        columns, _ = session_matrix(example_db)
+        assert columns[0] == "period"
+
+    def test_movement_columns_present(self, example_db):
+        columns, _ = session_matrix(example_db)
+        # squat and bench-press are in example.ox
+        assert "squat" in columns
+        assert "bench-press" in columns
+
+    def test_movements_sorted_by_frequency(self, example_db):
+        columns, _ = session_matrix(example_db)
+        movement_cols = columns[1:]
+        # Most frequent movement should be first
+        assert len(movement_cols) > 1
+
+    def test_rows_have_correct_length(self, example_db):
+        columns, rows = session_matrix(example_db)
+        for row in rows:
+            assert len(row) == len(columns)
+
+    def test_cells_are_integers(self, example_db):
+        _, rows = session_matrix(example_db)
+        for row in rows:
+            for cell in row[1:]:  # skip period string
+                assert isinstance(cell, int)
+
+    def test_zero_fill_for_missing(self, example_db):
+        """Movements not in a period should have 0, not None."""
+        _, rows = session_matrix(example_db)
+        for row in rows:
+            for cell in row[1:]:
+                assert cell >= 0
+
+    def test_monthly_bin(self, example_db):
+        columns, rows = session_matrix(example_db, bin="monthly")
+        assert len(rows) > 0
+        for row in rows:
+            assert len(row[0]) == 7  # "2024-01"
+
+    def test_empty_log(self):
+        log = TrainingLog(sessions=())
+        conn = create_db(log)
+        columns, rows = session_matrix(conn)
+        assert columns == ["period"]
+        assert rows == []
+        conn.close()
+
+
+class TestParseReportArgs:
+    """Test the argument parser."""
+
+    def test_basic_flags(self):
+        params = [
+            {"name": "movement", "type": str, "required": True},
+            {"name": "bin", "type": str, "default": "weekly", "required": False},
+        ]
+        result = parse_report_args(params, "--movement kb-swing --bin monthly")
+        assert result == {"movement": "kb-swing", "bin": "monthly"}
+
+    def test_default_applied(self):
+        params = [
+            {"name": "bin", "type": str, "default": "weekly", "required": False},
+        ]
+        result = parse_report_args(params, "")
+        assert result == {"bin": "weekly"}
+
+    def test_missing_required_raises(self):
+        params = [
+            {"name": "movement", "type": str, "required": True},
+        ]
+        with pytest.raises(ValueError, match="Missing required"):
+            parse_report_args(params, "")
+
+    def test_unknown_flag_raises(self):
+        params = [
+            {"name": "movement", "type": str, "required": True},
+        ]
+        with pytest.raises(ValueError, match="Unknown flag"):
+            parse_report_args(params, "--foo bar")
+
+    def test_flag_without_value_raises(self):
+        params = [
+            {"name": "movement", "type": str, "required": True},
+        ]
+        with pytest.raises(ValueError, match="requires a value"):
+            parse_report_args(params, "--movement")
+
+    def test_unexpected_positional_raises(self):
+        params = [
+            {"name": "movement", "type": str, "required": True},
+        ]
+        with pytest.raises(ValueError, match="Unexpected argument"):
+            parse_report_args(params, "kb-swing")
+
+    def test_quoted_value(self):
+        params = [
+            {"name": "movement", "type": str, "required": True},
+        ]
+        result = parse_report_args(params, '--movement "kb-swing"')
+        assert result == {"movement": "kb-swing"}
+
+
+class TestReportUsage:
+    """Test usage string generation."""
+
+    def test_volume_usage(self):
+        usage = report_usage("volume", REPORTS["volume"])
+        assert "--movement" in usage
+        assert "--bin" in usage
+        assert "report volume" in usage
+
+    def test_required_not_bracketed(self):
+        usage = report_usage("volume", REPORTS["volume"])
+        # Required params should not be in brackets
+        assert "[--movement" not in usage
+
+    def test_optional_bracketed(self):
+        usage = report_usage("volume", REPORTS["volume"])
+        # Optional params should be in brackets
+        assert "[--bin" in usage
+
+
+class TestRegistry:
+    """Test that the REPORTS registry is well-formed."""
+
+    def test_all_reports_have_fn(self):
+        for name, entry in REPORTS.items():
+            assert "fn" in entry, f"Report '{name}' missing 'fn'"
+            assert callable(entry["fn"])
+
+    def test_all_reports_have_description(self):
+        for name, entry in REPORTS.items():
+            assert "description" in entry, f"Report '{name}' missing 'description'"
+
+    def test_all_reports_have_params(self):
+        for name, entry in REPORTS.items():
+            assert "params" in entry, f"Report '{name}' missing 'params'"
+            assert isinstance(entry["params"], list)


### PR DESCRIPTION
## Summary                                                                                                                                                                                    
                                                                                                                                                                                                
  - **In-memory SQLite layer** (`db.py`) — parsed `.ox` logs are loaded into a `sessions → movements → sets` schema with a `training` view that joins everything. Enables arbitrary SQL queries 
  against training data.                                                                                                                                                                        
  - **Reports module** (`reports.py`) — `volume` (volume over time for a movement) and `matrix` (session count per movement per period) reports, with a registry and arg parser so new reports
  drop in easily.
  - **CLI commands** — `query`, `tables`, and `report` added to the REPL; tab-completion updated.
  - **Round-trip serialization** — `to_ox()` on `Movement` and `TrainingSession` for writing data back to `.ox` format.
  - **Compact weight string fix** — formatting bug resolved.
  - **Project docs** — added `SPEC.md` and `CLAUDE.md`.

  ## What changed

  | area | files | what |
  |------|-------|------|
  | query layer | `src/ox/db.py`, `tests/test_db.py` | SQLite schema, `create_db()`, 256 lines of tests |
  | reports | `src/ox/reports.py`, `tests/test_reports.py` | 2 built-in reports, arg parsing, registry |
  | CLI | `src/ox/cli.py` | `query`, `tables`, `report` commands |
  | data model | `src/ox/data.py` | `to_ox()` methods, `_format_weight` helper |
  | docs | `SPEC.md`, `CLAUDE.md` | product spec + contributor guide |

  ## Test plan

  - [x] `uv run pytest` passes (new tests for db, reports, and existing parse/integration tests)
  - [ ] Manual: `ox example/example.ox` → `query SELECT * FROM training LIMIT 5`
  - [ ] Manual: `report volume --movement bench-press`
  - [ ] Manual: `tables` lists sessions, movements, sets, training view