### PR TITLE
Add plugin system for extensible reports and generators

### DIFF
--- a/src/ox/cli.py
+++ b/src/ox/cli.py
@@ -15,7 +15,8 @@ from prompt_toolkit.completion import WordCompleter
 from ox.parse import process_node
 from ox.data import TrainingLog
 from ox.db import create_db
-from ox.reports import REPORTS, parse_report_args, report_usage
+from ox.plugins import GENERATOR_PLUGINS, load_plugins
+from ox.reports import get_all_reports, parse_report_args, report_usage
 
 console = Console()
 
@@ -60,6 +61,9 @@ def show_help():
     )
     console.print(
         "  [green]report[/green]             - List available reports (or run one)"
+    )
+    console.print(
+        "  [green]generate[/green]           - List available generators (or run one)"
     )
     console.print(
         "  [green]query[/green] SQL          - Run a SQL query against your training data"
@@ -167,7 +171,7 @@ def show_tables(conn: sqlite3.Connection):
 def show_report_list():
     """Show available reports with descriptions and usage."""
     console.print("\n[bold cyan]Available Reports:[/bold cyan]")
-    for name, entry in REPORTS.items():
+    for name, entry in get_all_reports().items():
         usage = report_usage(name, entry)
         console.print(f"  [green]{name}[/green] - {entry['description']}")
         console.print(f"    Usage: {usage}")
@@ -193,12 +197,13 @@ def render_report(columns: list[str], rows: list[tuple]):
 
 def run_report(conn: sqlite3.Connection, report_name: str, arg_string: str):
     """Look up and execute a report by name."""
-    if report_name not in REPORTS:
+    all_reports = get_all_reports()
+    if report_name not in all_reports:
         console.print(f"[red]Unknown report: {report_name}[/red]")
         show_report_list()
         return
 
-    entry = REPORTS[report_name]
+    entry = all_reports[report_name]
 
     if not arg_string.strip() and any(p.get("required") for p in entry["params"]):
         usage = report_usage(report_name, entry)
@@ -209,6 +214,44 @@ def run_report(conn: sqlite3.Connection, report_name: str, arg_string: str):
         kwargs = parse_report_args(entry["params"], arg_string)
         columns, rows = entry["fn"](conn, **kwargs)
         render_report(columns, rows)
+    except ValueError as e:
+        console.print(f"[red]{e}[/red]\n")
+
+
+def show_generator_list():
+    """Show available generators with descriptions and usage."""
+    if not GENERATOR_PLUGINS:
+        console.print("[yellow]No generator plugins installed.[/yellow]\n")
+        return
+    console.print("\n[bold cyan]Available Generators:[/bold cyan]")
+    for name, entry in GENERATOR_PLUGINS.items():
+        usage = report_usage(name, entry, command="generate")
+        console.print(f"  [green]{name}[/green] - {entry['description']}")
+        console.print(f"    Usage: {usage}")
+    console.print()
+
+
+def run_generator(conn: sqlite3.Connection, gen_name: str, arg_string: str):
+    """Look up and execute a generator by name."""
+    if gen_name not in GENERATOR_PLUGINS:
+        console.print(f"[red]Unknown generator: {gen_name}[/red]")
+        show_generator_list()
+        return
+
+    entry = GENERATOR_PLUGINS[gen_name]
+
+    if not arg_string.strip() and any(p.get("required") for p in entry["params"]):
+        usage = report_usage(gen_name, entry, command="generate")
+        console.print(f"[yellow]Usage: {usage}[/yellow]\n")
+        return
+
+    try:
+        kwargs = parse_report_args(entry["params"], arg_string)
+        if entry.get("needs_db"):
+            output = entry["fn"](conn, **kwargs)
+        else:
+            output = entry["fn"](**kwargs)
+        console.print(output)
     except ValueError as e:
         console.print(f"[red]{e}[/red]\n")
 
@@ -226,6 +269,7 @@ def cli(file):
         console.print(f"[cyan]Loading {file}...[/cyan]")
         log = parse_file(file)
         db = create_db(log)
+        load_plugins()
         console.print(
             f"[green]✓[/green] Loaded {len(log.completed_sessions)} completed, "
             f"{len(log.planned_sessions)} planned sessions\n"
@@ -235,17 +279,7 @@ def cli(file):
         raise click.Abort()
 
     # Setup tab completion for commands
-    commands = [
-        "history",
-        "stats",
-        "report",
-        "query",
-        "tables",
-        "reload",
-        "help",
-        "exit",
-        "quit",
-    ]
+    commands = ["history", "stats", "report", "reload", "generate", "query", "tables", "help", "exit", "quit"]
     completer = WordCompleter(commands, ignore_case=True)
 
     # Create prompt session
@@ -291,6 +325,15 @@ def cli(file):
                     report_name = parts2[0]
                     report_args = parts2[1] if len(parts2) > 1 else ""
                     run_report(db, report_name, report_args)
+
+            elif command == "generate":
+                if not args:
+                    show_generator_list()
+                else:
+                    parts2 = args.split(maxsplit=1)
+                    gen_name = parts2[0]
+                    gen_args = parts2[1] if len(parts2) > 1 else ""
+                    run_generator(db, gen_name, gen_args)
 
             elif command == "query":
                 if not args:

--- a/src/ox/cli.py
+++ b/src/ox/cli.py
@@ -279,7 +279,18 @@ def cli(file):
         raise click.Abort()
 
     # Setup tab completion for commands
-    commands = ["history", "stats", "report", "reload", "generate", "query", "tables", "help", "exit", "quit"]
+    commands = [
+        "history",
+        "stats",
+        "report",
+        "reload",
+        "generate",
+        "query",
+        "tables",
+        "help",
+        "exit",
+        "quit",
+    ]
     completer = WordCompleter(commands, ignore_case=True)
 
     # Create prompt session

--- a/src/ox/plugins.py
+++ b/src/ox/plugins.py
@@ -76,9 +76,7 @@ def _load_from_directory() -> None:
                 descriptors = module.register()
                 _register_descriptors(descriptors, str(path))
             except Exception:
-                logger.warning(
-                    "Error calling register() in %s", path, exc_info=True
-                )
+                logger.warning("Error calling register() in %s", path, exc_info=True)
 
 
 def _load_from_entry_points() -> None:
@@ -90,9 +88,7 @@ def _load_from_entry_points() -> None:
                 descriptors = module.register()
                 _register_descriptors(descriptors, f"entry_point:{ep.name}")
         except Exception:
-            logger.warning(
-                "Error loading entry point '%s'", ep.name, exc_info=True
-            )
+            logger.warning("Error loading entry point '%s'", ep.name, exc_info=True)
 
 
 def load_plugins() -> None:

--- a/src/ox/plugins.py
+++ b/src/ox/plugins.py
@@ -1,0 +1,103 @@
+"""Plugin discovery and loading for ox.
+
+Plugins are Python modules that export a register() function returning
+a list of plugin descriptors (dicts). Two plugin types are supported:
+
+- "report": query SQLite, return (columns, rows)
+- "generator": accept parameters, return .ox formatted text
+
+Discovery sources (loaded in order):
+1. ~/.ox/plugins/*.py  (personal scripts)
+2. Entry points in the "ox.plugins" group (installable packages)
+"""
+
+import importlib.util
+import logging
+from importlib.metadata import entry_points
+from pathlib import Path
+from types import ModuleType
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_DIR = Path.home() / ".ox" / "plugins"
+ENTRY_POINT_GROUP = "ox.plugins"
+
+REPORT_PLUGINS: dict[str, dict] = {}
+GENERATOR_PLUGINS: dict[str, dict] = {}
+
+
+def _load_module_from_path(path: Path) -> ModuleType | None:
+    """Import a .py file as a module. Returns None on failure."""
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    if spec is None or spec.loader is None:
+        logger.warning("Could not load plugin: %s", path)
+        return None
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        logger.warning("Error loading plugin %s", path, exc_info=True)
+        return None
+    return module
+
+
+def _register_descriptors(descriptors: list[dict], source: str) -> None:
+    """Register plugin descriptors into the appropriate registry."""
+    for desc in descriptors:
+        plugin_type = desc.get("type")
+        name = desc.get("name")
+
+        if not plugin_type or not name or "fn" not in desc:
+            logger.warning(
+                "Skipping malformed plugin descriptor from %s: %s", source, desc
+            )
+            continue
+
+        if plugin_type == "report":
+            if name in REPORT_PLUGINS:
+                logger.warning("Report plugin '%s' redefined by %s", name, source)
+            REPORT_PLUGINS[name] = desc
+        elif plugin_type == "generator":
+            if name in GENERATOR_PLUGINS:
+                logger.warning("Generator plugin '%s' redefined by %s", name, source)
+            GENERATOR_PLUGINS[name] = desc
+        else:
+            logger.warning("Unknown plugin type '%s' from %s", plugin_type, source)
+
+
+def _load_from_directory() -> None:
+    """Load all .py files from ~/.ox/plugins/."""
+    if not PLUGIN_DIR.is_dir():
+        return
+    for path in sorted(PLUGIN_DIR.glob("*.py")):
+        module = _load_module_from_path(path)
+        if module and hasattr(module, "register"):
+            try:
+                descriptors = module.register()
+                _register_descriptors(descriptors, str(path))
+            except Exception:
+                logger.warning(
+                    "Error calling register() in %s", path, exc_info=True
+                )
+
+
+def _load_from_entry_points() -> None:
+    """Load plugins registered via entry points."""
+    for ep in entry_points(group=ENTRY_POINT_GROUP):
+        try:
+            module = ep.load()
+            if hasattr(module, "register"):
+                descriptors = module.register()
+                _register_descriptors(descriptors, f"entry_point:{ep.name}")
+        except Exception:
+            logger.warning(
+                "Error loading entry point '%s'", ep.name, exc_info=True
+            )
+
+
+def load_plugins() -> None:
+    """Discover and load all plugins. Call once at startup."""
+    REPORT_PLUGINS.clear()
+    GENERATOR_PLUGINS.clear()
+    _load_from_directory()
+    _load_from_entry_points()

--- a/src/ox/reports.py
+++ b/src/ox/reports.py
@@ -182,17 +182,18 @@ def parse_report_args(params: list[dict], arg_string: str) -> dict:
     return parsed
 
 
-def report_usage(name: str, entry: dict) -> str:
-    """Generate a usage string for a report.
+def report_usage(name: str, entry: dict, command: str = "report") -> str:
+    """Generate a usage string for a report or generator.
 
     Args:
-        name: Report name
-        entry: Report registry entry
+        name: Report/generator name
+        entry: Registry entry with params list
+        command: CLI command prefix ("report" or "generate")
 
     Returns:
         Formatted usage string
     """
-    parts = [f"report {name}"]
+    parts = [f"{command} {name}"]
     for p in entry["params"]:
         short = f"-{p['short']}/" if p.get("short") else ""
         flag = f"{short}--{p['name']} <{p['name']}>"
@@ -232,3 +233,17 @@ REPORTS = {
         ],
     },
 }
+
+
+def get_all_reports() -> dict[str, dict]:
+    """Return built-in reports merged with plugin reports."""
+    from ox.plugins import REPORT_PLUGINS
+
+    merged = dict(REPORTS)
+    for name, desc in REPORT_PLUGINS.items():
+        merged[name] = {
+            "fn": desc["fn"],
+            "description": desc["description"],
+            "params": desc["params"],
+        }
+    return merged

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,291 @@
+"""Tests for the plugin system."""
+
+import textwrap
+
+from ox.plugins import (
+    GENERATOR_PLUGINS,
+    REPORT_PLUGINS,
+    _load_from_directory,
+    _register_descriptors,
+    load_plugins,
+)
+from ox.reports import REPORTS, get_all_reports, report_usage
+
+
+def _dummy_report(conn, movement="x"):
+    return ["col"], [("row",)]
+
+
+def _dummy_generator(movement="x"):
+    return "output"
+
+
+class TestRegisterDescriptors:
+    """Test descriptor routing and validation."""
+
+    def setup_method(self):
+        REPORT_PLUGINS.clear()
+        GENERATOR_PLUGINS.clear()
+
+    def test_routes_report(self):
+        _register_descriptors(
+            [
+                {
+                    "type": "report",
+                    "name": "test-report",
+                    "fn": _dummy_report,
+                    "description": "A test",
+                    "params": [],
+                }
+            ],
+            "test",
+        )
+        assert "test-report" in REPORT_PLUGINS
+        assert GENERATOR_PLUGINS == {}
+
+    def test_routes_generator(self):
+        _register_descriptors(
+            [
+                {
+                    "type": "generator",
+                    "name": "test-gen",
+                    "fn": _dummy_generator,
+                    "description": "A test",
+                    "params": [],
+                }
+            ],
+            "test",
+        )
+        assert "test-gen" in GENERATOR_PLUGINS
+        assert REPORT_PLUGINS == {}
+
+    def test_skips_missing_fn(self):
+        _register_descriptors(
+            [{"type": "report", "name": "bad", "description": "no fn"}],
+            "test",
+        )
+        assert REPORT_PLUGINS == {}
+
+    def test_skips_missing_name(self):
+        _register_descriptors(
+            [{"type": "report", "fn": _dummy_report}],
+            "test",
+        )
+        assert REPORT_PLUGINS == {}
+
+    def test_skips_missing_type(self):
+        _register_descriptors(
+            [{"name": "bad", "fn": _dummy_report}],
+            "test",
+        )
+        assert REPORT_PLUGINS == {}
+
+    def test_skips_unknown_type(self):
+        _register_descriptors(
+            [{"type": "widget", "name": "bad", "fn": _dummy_report}],
+            "test",
+        )
+        assert REPORT_PLUGINS == {}
+        assert GENERATOR_PLUGINS == {}
+
+    def test_name_collision_overwrites(self):
+        desc = {
+            "type": "report",
+            "name": "dup",
+            "fn": _dummy_report,
+            "description": "first",
+            "params": [],
+        }
+        _register_descriptors([desc], "first-source")
+        assert REPORT_PLUGINS["dup"]["description"] == "first"
+
+        desc2 = {**desc, "description": "second"}
+        _register_descriptors([desc2], "second-source")
+        assert REPORT_PLUGINS["dup"]["description"] == "second"
+
+    def test_multiple_descriptors_in_one_call(self):
+        _register_descriptors(
+            [
+                {
+                    "type": "report",
+                    "name": "r1",
+                    "fn": _dummy_report,
+                    "description": "r",
+                    "params": [],
+                },
+                {
+                    "type": "generator",
+                    "name": "g1",
+                    "fn": _dummy_generator,
+                    "description": "g",
+                    "params": [],
+                },
+            ],
+            "test",
+        )
+        assert "r1" in REPORT_PLUGINS
+        assert "g1" in GENERATOR_PLUGINS
+
+
+class TestLoadFromDirectory:
+    """Test file-based plugin discovery."""
+
+    def setup_method(self):
+        REPORT_PLUGINS.clear()
+        GENERATOR_PLUGINS.clear()
+
+    def test_loads_plugin_from_directory(self, tmp_path, monkeypatch):
+        plugin_code = textwrap.dedent("""\
+            def _my_fn(conn, x="y"):
+                return ["col"], [("row",)]
+
+            def register():
+                return [
+                    {
+                        "type": "report",
+                        "name": "from-dir",
+                        "fn": _my_fn,
+                        "description": "loaded from dir",
+                        "params": [],
+                    }
+                ]
+        """)
+        (tmp_path / "my_plugin.py").write_text(plugin_code)
+        monkeypatch.setattr("ox.plugins.PLUGIN_DIR", tmp_path)
+        _load_from_directory()
+        assert "from-dir" in REPORT_PLUGINS
+
+    def test_ignores_file_without_register(self, tmp_path, monkeypatch):
+        (tmp_path / "no_register.py").write_text("x = 1\n")
+        monkeypatch.setattr("ox.plugins.PLUGIN_DIR", tmp_path)
+        _load_from_directory()
+        assert REPORT_PLUGINS == {}
+
+    def test_handles_register_error(self, tmp_path, monkeypatch):
+        plugin_code = textwrap.dedent("""\
+            def register():
+                raise RuntimeError("boom")
+        """)
+        (tmp_path / "bad_plugin.py").write_text(plugin_code)
+        monkeypatch.setattr("ox.plugins.PLUGIN_DIR", tmp_path)
+        _load_from_directory()
+        assert REPORT_PLUGINS == {}
+
+    def test_handles_import_error(self, tmp_path, monkeypatch):
+        (tmp_path / "broken.py").write_text("import nonexistent_module_xyz\n")
+        monkeypatch.setattr("ox.plugins.PLUGIN_DIR", tmp_path)
+        _load_from_directory()
+        assert REPORT_PLUGINS == {}
+
+    def test_nonexistent_directory(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ox.plugins.PLUGIN_DIR", tmp_path / "nope")
+        _load_from_directory()
+        assert REPORT_PLUGINS == {}
+
+
+class TestLoadPlugins:
+    """Test the top-level load_plugins function."""
+
+    def test_idempotent(self, tmp_path, monkeypatch):
+        plugin_code = textwrap.dedent("""\
+            def _fn(conn):
+                return [], []
+
+            def register():
+                return [
+                    {
+                        "type": "report",
+                        "name": "idem",
+                        "fn": _fn,
+                        "description": "test",
+                        "params": [],
+                    }
+                ]
+        """)
+        (tmp_path / "idem.py").write_text(plugin_code)
+        monkeypatch.setattr("ox.plugins.PLUGIN_DIR", tmp_path)
+
+        load_plugins()
+        assert "idem" in REPORT_PLUGINS
+
+        load_plugins()
+        assert "idem" in REPORT_PLUGINS
+        assert len(REPORT_PLUGINS) == 1
+
+    def test_clears_previous(self, tmp_path, monkeypatch):
+        """After removing a plugin file, reload should not keep stale entries."""
+        plugin_code = textwrap.dedent("""\
+            def _fn(conn):
+                return [], []
+
+            def register():
+                return [
+                    {
+                        "type": "report",
+                        "name": "gone",
+                        "fn": _fn,
+                        "description": "test",
+                        "params": [],
+                    }
+                ]
+        """)
+        plugin_file = tmp_path / "gone.py"
+        plugin_file.write_text(plugin_code)
+        monkeypatch.setattr("ox.plugins.PLUGIN_DIR", tmp_path)
+
+        load_plugins()
+        assert "gone" in REPORT_PLUGINS
+
+        plugin_file.unlink()
+        load_plugins()
+        assert "gone" not in REPORT_PLUGINS
+
+
+class TestGetAllReports:
+    """Test merging built-in reports with plugin reports."""
+
+    def setup_method(self):
+        REPORT_PLUGINS.clear()
+
+    def test_returns_builtins_when_no_plugins(self):
+        result = get_all_reports()
+        assert "volume" in result
+        assert "matrix" in result
+
+    def test_merges_plugin_reports(self):
+        REPORT_PLUGINS["custom"] = {
+            "type": "report",
+            "name": "custom",
+            "fn": _dummy_report,
+            "description": "Custom report",
+            "params": [{"name": "x", "type": str, "required": True}],
+        }
+        result = get_all_reports()
+        assert "volume" in result
+        assert "custom" in result
+        assert result["custom"]["fn"] is _dummy_report
+
+    def test_does_not_mutate_builtins(self):
+        REPORT_PLUGINS["custom"] = {
+            "type": "report",
+            "name": "custom",
+            "fn": _dummy_report,
+            "description": "Custom report",
+            "params": [],
+        }
+        get_all_reports()
+        assert "custom" not in REPORTS
+
+
+class TestReportUsageCommand:
+    """Test that report_usage respects the command parameter."""
+
+    def test_default_command(self):
+        entry = {"params": [{"name": "x", "type": str, "required": True}]}
+        usage = report_usage("test", entry)
+        assert usage.startswith("report test")
+
+    def test_generate_command(self):
+        entry = {"params": [{"name": "x", "type": str, "required": True}]}
+        usage = report_usage("test", entry, command="generate")
+        assert usage.startswith("generate test")

--- a/tree-sitter-ox/bindings/python/tree_sitter_ox/__init__.py
+++ b/tree-sitter-ox/bindings/python/tree_sitter_ox/__init__.py
@@ -36,7 +36,18 @@ __all__ = [
 
 
 def __dir__():
-    return sorted(__all__ + [
-        "__all__", "__builtins__", "__cached__", "__doc__", "__file__",
-        "__loader__", "__name__", "__package__", "__path__", "__spec__",
-    ])
+    return sorted(
+        __all__
+        + [
+            "__all__",
+            "__builtins__",
+            "__cached__",
+            "__doc__",
+            "__file__",
+            "__loader__",
+            "__name__",
+            "__package__",
+            "__path__",
+            "__spec__",
+        ]
+    )

--- a/tree-sitter-ox/setup.py
+++ b/tree-sitter-ox/setup.py
@@ -73,5 +73,5 @@ setup(
         "bdist_wheel": BdistWheel,
         "egg_info": EggInfo,
     },
-    zip_safe=False
+    zip_safe=False,
 )


### PR DESCRIPTION
Plugins are Python modules with a register() function that returns descriptors. Two types: "report" (queries SQLite, returns columns/rows) and "generator" (produces .ox text). Discovery via ~/.ox/plugins/*.py and ox.plugins entry points. Fixes #13