### PR TITLE
Add linter with parse diagnostic reporting

### DIFF
--- a/src/ox/data.py
+++ b/src/ox/data.py
@@ -9,6 +9,16 @@ DATE_FORMAT = "%Y-%m-%d"
 ITEM_FIELDS = ["weight", "rep_scheme", "time", "distance", "note"]
 
 
+@dataclass(frozen=True, slots=True)
+class Diagnostic:
+    line: int  # 1-based line number
+    col: int  # 0-based column
+    end_line: int
+    end_col: int
+    message: str
+    severity: str  # "error" | "warning"
+
+
 def _format_weight(weight: Quantity) -> str:
     """Format a Quantity as an ox weight string like '24kg' or '135lb'."""
     unit_map = {"kilogram": "kg", "pound": "lb"}
@@ -159,9 +169,11 @@ class TrainingLog:
 
     Attributes:
         sessions: Tuple of TrainingSession objects
+        diagnostics: Tuple of parse diagnostics (errors/warnings)
     """
 
     sessions: tuple[TrainingSession, ...]
+    diagnostics: tuple[Diagnostic, ...] = field(default_factory=tuple)
 
     @property
     def completed_sessions(self) -> tuple[TrainingSession, ...]:

--- a/src/ox/lint.py
+++ b/src/ox/lint.py
@@ -1,0 +1,39 @@
+"""Lint utilities for ox training log files."""
+
+from ox.data import Diagnostic
+
+
+def collect_diagnostics(tree) -> tuple[Diagnostic, ...]:
+    """Walk a tree-sitter tree and collect ERROR/MISSING nodes as Diagnostics."""
+    diagnostics = []
+
+    def visit(node):
+        if node.type == "ERROR":
+            diagnostics.append(
+                Diagnostic(
+                    line=node.start_point[0] + 1,
+                    col=node.start_point[1],
+                    end_line=node.end_point[0] + 1,
+                    end_col=node.end_point[1],
+                    message="Syntax error",
+                    severity="error",
+                )
+            )
+            return  # don't recurse into ERROR subtrees
+        if node.is_missing:
+            diagnostics.append(
+                Diagnostic(
+                    line=node.start_point[0] + 1,
+                    col=node.start_point[1],
+                    end_line=node.end_point[0] + 1,
+                    end_col=node.end_point[1],
+                    message=f"Missing {node.type}",
+                    severity="error",
+                )
+            )
+            return
+        for child in node.children:
+            visit(child)
+
+    visit(tree.root_node)
+    return tuple(diagnostics)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,0 +1,125 @@
+"""Tests for lint/diagnostic reporting."""
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from ox.cli import cli, parse_file
+from ox.lint import collect_diagnostics
+from ox.data import Diagnostic
+
+from tree_sitter import Language, Parser
+import tree_sitter_ox
+
+
+def _parse_tree(text: str):
+    language = Language(tree_sitter_ox.language())
+    parser = Parser(language)
+    return parser.parse(bytes(text, encoding="utf-8"))
+
+
+class TestCollectDiagnostics:
+    def test_valid_file_no_diagnostics(self):
+        text = "2025-01-10 * pullups: BW 5x10\n"
+        tree = _parse_tree(text)
+        assert collect_diagnostics(tree) == ()
+
+    def test_lbs_unit_produces_diagnostic(self):
+        # "lbs" is not a valid unit; valid unit is "lb"
+        text = "2025-01-10 * bench-press: 135lbs 5x5\n"
+        tree = _parse_tree(text)
+        diagnostics = collect_diagnostics(tree)
+        assert len(diagnostics) == 1
+        d = diagnostics[0]
+        assert isinstance(d, Diagnostic)
+        assert d.line == 1
+        assert d.severity == "error"
+
+    def test_multiple_errors_all_collected(self):
+        text = "2025-01-10 * bench-press: 135lbs 5x5\n2025-01-11 * squat: 225lbs 3x5\n"
+        tree = _parse_tree(text)
+        diagnostics = collect_diagnostics(tree)
+        assert len(diagnostics) >= 2
+
+    def test_diagnostic_fields(self):
+        text = "2025-01-10 * bench-press: 135lbs 5x5\n"
+        tree = _parse_tree(text)
+        diagnostics = collect_diagnostics(tree)
+        assert len(diagnostics) >= 1
+        d = diagnostics[0]
+        assert d.line >= 1
+        assert d.col >= 0
+        assert d.end_line >= d.line
+        assert d.message in ("Syntax error", f"Missing {d.message.split()[-1]}")
+        assert d.severity == "error"
+
+    def test_multiline_session_valid(self):
+        text = "@session\n2025-01-11 * Upper Day\nbench-press: 135lb 5x5\n@end\n"
+        tree = _parse_tree(text)
+        assert collect_diagnostics(tree) == ()
+
+
+class TestTrainingLogDiagnostics:
+    def test_parse_file_valid_log_no_diagnostics(self, simple_log_file):
+        log = parse_file(simple_log_file)
+        assert log.diagnostics == ()
+
+    def test_parse_file_invalid_log_has_diagnostics(self, tmp_path):
+        bad_file = tmp_path / "bad.ox"
+        bad_file.write_text("2025-01-10 * bench-press: 135lbs 5x5\n")
+        log = parse_file(bad_file)
+        assert len(log.diagnostics) >= 1
+        assert all(isinstance(d, Diagnostic) for d in log.diagnostics)
+
+    def test_diagnostics_correct_line(self, tmp_path):
+        content = (
+            "# comment\n"
+            "2025-01-10 * pullups: BW 5x10\n"
+            "2025-01-11 * bench-press: 135lbs 5x5\n"
+        )
+        bad_file = tmp_path / "bad.ox"
+        bad_file.write_text(content)
+        log = parse_file(bad_file)
+        assert len(log.diagnostics) >= 1
+        # The bad line is line 3
+        assert any(d.line == 3 for d in log.diagnostics)
+
+
+def _invoke_repl(file_path, commands: list[str]):
+    """Invoke the CLI REPL with a sequence of commands, mocking prompt_toolkit."""
+    runner = CliRunner()
+    cmd_iter = iter(commands + ["exit"])
+
+    def mock_prompt(_self, *args, **kwargs):
+        return next(cmd_iter)
+
+    with patch("prompt_toolkit.PromptSession.prompt", mock_prompt):
+        return runner.invoke(cli, [str(file_path)])
+
+
+class TestLintCommand:
+    def test_lint_no_errors(self, simple_log_file):
+        result = _invoke_repl(simple_log_file, ["lint"])
+        assert result.exit_code == 0
+        assert "No parse errors found" in result.output
+
+    def test_lint_shows_errors(self, tmp_path):
+        bad_file = tmp_path / "bad.ox"
+        bad_file.write_text("2025-01-10 * bench-press: 135lbs 5x5\n")
+        result = _invoke_repl(bad_file, ["lint"])
+        assert result.exit_code == 0
+        assert "Line" in result.output
+        assert "Syntax error" in result.output
+
+    def test_load_warning_shown_when_errors(self, tmp_path):
+        bad_file = tmp_path / "bad.ox"
+        bad_file.write_text("2025-01-10 * bench-press: 135lbs 5x5\n")
+        result = _invoke_repl(bad_file, [])
+        assert result.exit_code == 0
+        assert "parse error" in result.output.lower()
+        assert "lint" in result.output
+
+    def test_no_load_warning_for_valid_file(self, simple_log_file):
+        result = _invoke_repl(simple_log_file, [])
+        assert result.exit_code == 0
+        assert "parse error" not in result.output.lower()

--- a/tree-sitter-ox/test/corpus/multiline_entry.txt
+++ b/tree-sitter-ox/test/corpus/multiline_entry.txt
@@ -7,7 +7,7 @@ Multiline Entry
 kb-snatch: 32kg 5x4
 kb-tgu: 32kg 5x1 "a note" 3min
 kb-sldl: 24kg+32kg 5/5/5
-deadlift: 105lbs/150lbs/170lbs 5/5/5
+deadlift: 105lb/150lb/170lb 5/5/5
 @end
 
 ---

--- a/tree-sitter-ox/test/corpus/singleline_entry_weighin.txt
+++ b/tree-sitter-ox/test/corpus/singleline_entry_weighin.txt
@@ -2,7 +2,7 @@
 Singleline Entry Weighin
 ========================
 
-2025-11-13 W superfly-1: 155lbs "noon"
+2025-11-13 W superfly-1: 155lb "noon"
 
 ---
 


### PR DESCRIPTION
Extract tree-sitter error detection into a shared lint.py module with a Diagnostic dataclass, so both the CLI and LSP surface parse errors to users. The CLI now warns on load/reload when errors are found and provides a `lint` REPL command showing each error's line and column.